### PR TITLE
adding ` around USE

### DIFF
--- a/myphp-backup.php
+++ b/myphp-backup.php
@@ -122,7 +122,7 @@ class Backup_Database {
             }
 
             $sql = 'CREATE DATABASE IF NOT EXISTS `'.$this->dbName."`;\n\n";
-            $sql .= 'USE '.$this->dbName.";\n\n";
+            $sql .= 'USE `'.$this->dbName."`;\n\n";
 
             /**
             * Iterate tables


### PR DESCRIPTION
if your dbname includes - e.g. epicness-database you will get a mysql error in your restore php. the ` fixes this.
otherwise great code! thanks heaps for sharing, tested backup and restore, both worked great after that fix